### PR TITLE
Fix missing process pid attribute

### DIFF
--- a/lib/OpenTracing/Process.pm
+++ b/lib/OpenTracing/Process.pm
@@ -34,6 +34,14 @@ The process name. Freeform text string.
 
 sub name { shift->{name} //= "$0" }
 
+=head2 pid
+
+The process pid.
+
+=cut
+
+sub pid { shift->{pid} //= $$ }
+
 =head2 tags
 
 Arrayref of tags relating to the process.


### PR DESCRIPTION
Fixes

`Can't locate object method "pid" via package "OpenTracing::Process"`