### PR TITLE
Added references

### DIFF
--- a/lib/OpenTracing.pm
+++ b/lib/OpenTracing.pm
@@ -198,6 +198,7 @@ use OpenTracing::Span;
 use OpenTracing::SpanProxy;
 use OpenTracing::Process;
 use OpenTracing::Tracer;
+use OpenTracing::Reference;
 
 our $TRACER = OpenTracing::Tracer->new;
 

--- a/lib/OpenTracing/Process.pm
+++ b/lib/OpenTracing/Process.pm
@@ -26,6 +26,14 @@ concept.
 
 =head1 METHODS
 
+=head2 pid
+
+The process pid.
+
+=cut
+
+sub pid { shift->{pid} //= $$ }
+
 =head2 name
 
 The process name. Freeform text string.

--- a/lib/OpenTracing/Protocol/Jaeger.pm
+++ b/lib/OpenTracing/Protocol/Jaeger.pm
@@ -186,19 +186,19 @@ sub encode_span {
             data .= pack 'C1n1N1 CnH16 CnH16 CnH16 C1',
                     8, # type = int32 (enum)
                     1,
-                    $span_ref->ref_type,
+                    $references->ref_type,
                     # trace_id_low
                     10,
                     2,
-                    substr($span_ref->span->trace_id, 16, 16),
+                    substr($references->span->trace_id, 16, 16),
                     # trace_id_high
                     10,
                     3,
-                    substr($span_ref->span->trace_id, 0, 16),
+                    substr($references->span->trace_id, 0, 16),
                     # span_id
                     10,
                     4,
-                    substr($span_ref->span->id, 0, 16),
+                    substr($references->span->id, 0, 16),
                     0;
         }
     }

--- a/lib/OpenTracing/Protocol/Jaeger.pm
+++ b/lib/OpenTracing/Protocol/Jaeger.pm
@@ -76,13 +76,13 @@ byte string representing that data.
 sub encode_tags {
     my ($self, $field_id, $tags) = @_;
     my $data = '';
-      # list Tag
+    # list Tag
     $data .= pack 'C1n1 C1N1',
         15, # list
         $field_id, # field ID is usually 2, or 10 for spans
         12, # struct
-        0 + keys %$tags if %$tags;  
-   for my $k (sort keys %$tags) {
+        0 + keys %$tags if %$tags;
+    for my $k (sort keys %$tags) {
         $data .= pack 'C1n1N/a* C1n1N1 C1n1N/a* C1',
             11, # type = string
             1, # field ID = 1
@@ -94,8 +94,8 @@ sub encode_tags {
             3, # field ID = 3
             encode_utf8($tags->{$k} // ''),
             0; # EOF marker
-   }
-return $data;
+    }
+    return $data;
 }
 
 =head2 encode_process
@@ -155,7 +155,7 @@ sub encode_span {
     $data .= pack 'CnH16 CnH16 CnH16 CnH16 CnN/a*',
         # trace_id_low
         10,
-        1,  
+        1,
         substr($span->trace_id, 16, 16),
         # trace_id_high
         10,

--- a/lib/OpenTracing/Protocol/Jaeger.pm
+++ b/lib/OpenTracing/Protocol/Jaeger.pm
@@ -186,19 +186,19 @@ sub encode_span {
             $data .= pack 'C1n1N1 CnH16 CnH16 CnH16 C1',
                     8, # type = int32 (enum)
                     1,
-                    $references->ref_type,
+                    $reference->ref_type,
                     # trace_id_low
                     10,
                     2,
-                    substr($references->span->trace_id, 16, 16),
+                    substr($reference->span->trace_id, 16, 16),
                     # trace_id_high
                     10,
                     3,
-                    substr($references->span->trace_id, 0, 16),
+                    substr($reference->span->trace_id, 0, 16),
                     # span_id
                     10,
                     4,
-                    substr($references->span->id, 0, 16),
+                    substr($reference->span->id, 0, 16),
                     0;
         }
     }

--- a/lib/OpenTracing/Protocol/Jaeger.pm
+++ b/lib/OpenTracing/Protocol/Jaeger.pm
@@ -183,7 +183,7 @@ sub encode_span {
             12, # struct
             0 + @$references;
         for my $reference (@$references) {
-            data .= pack 'C1n1N1 CnH16 CnH16 CnH16 C1',
+            $data .= pack 'C1n1N1 CnH16 CnH16 CnH16 C1',
                     8, # type = int32 (enum)
                     1,
                     $references->ref_type,

--- a/lib/OpenTracing/Reference.pm
+++ b/lib/OpenTracing/Reference.pm
@@ -1,0 +1,50 @@
+package OpenTracing::Reference;
+
+use strict;
+use warnings;
+
+# VERSION
+# AUTHORITY
+
+use parent qw(OpenTracing::Common);
+
+no indirect;
+use utf8;
+
+=encoding utf8
+
+=head1 NAME
+
+OpenTracing::Reference - represents a span Reference
+
+=head1 DESCRIPTION
+
+=cut
+
+=head2 ref_type
+
+The type of reference
+
+=cut
+
+sub ref_type { shift->{ref_type} }
+
+=head2 span
+
+The span for this reference.
+
+=cut
+
+sub span { shift->{span} }
+
+1;
+
+__END__
+
+=head1 AUTHOR
+
+Tom Molesworth <TEAM@cpan.org>
+
+=head1 LICENSE
+
+Copyright Tom Molesworth 2018-2020. Licensed under the same terms as Perl itself.

--- a/lib/OpenTracing/Reference.pm
+++ b/lib/OpenTracing/Reference.pm
@@ -11,6 +11,11 @@ use parent qw(OpenTracing::Common);
 no indirect;
 use utf8;
 
+use constant {
+    CHILD_OF => 0,
+    FOLLOWS_FROM => 1,
+};
+
 =encoding utf8
 
 =head1 NAME

--- a/lib/OpenTracing/Span.pm
+++ b/lib/OpenTracing/Span.pm
@@ -210,6 +210,37 @@ sub tag : method {
     return $self;
 }
 
+=head2 references
+
+The references relating to this span.
+
+=cut
+
+sub references { shift->{references} }
+
+=head2 reference_list
+
+A list of reference entries for this span, as L<OpenTracing::Reference> instances.
+
+=cut
+
+sub reference_list { 
+    (shift->{references} //= [])->@*
+}
+
+
+=head2 reference
+
+Records a reference.
+
+=cut
+
+sub reference : method {
+    my ($self, %args) = @_;
+    push +($self->{references} //= [])->@*, my $reference = OpenTracing::Reference->new(%args);
+    $reference;
+}
+
 =head2 tracer
 
 Returns the L<OpenTracing::Tracer> for this span.

--- a/lib/OpenTracing/SpanProxy.pm
+++ b/lib/OpenTracing/SpanProxy.pm
@@ -55,6 +55,10 @@ sub tags { shift->span->tags }
 
 sub tag { shift->span->tag(@_) }
 
+sub reference { shift->span->reference(@_) }
+
+sub references { shift->span->references }
+
 sub start_time { shift->span->start_time }
 
 sub duration { shift->span->duration(@_) }

--- a/lib/OpenTracing/Tracer.pm
+++ b/lib/OpenTracing/Tracer.pm
@@ -62,9 +62,11 @@ sub process {
     $self->{process} //= do {
         require Net::Address::IP::Local;
         OpenTracing::Process->new(
-            pid              => $$,
-            ip               => Net::Address::IP::Local->public_ipv4,
-            'tracer.version' => 'perl-OpenTracing-' . (__PACKAGE__->VERSION // "0.0.0"),
+            tags => {
+                pid              => $$,
+                ip               => Net::Address::IP::Local->public_ipv4,
+                'tracer.version' => 'perl-OpenTracing-' . (__PACKAGE__->VERSION // "0.0.0"),
+            }
         );
     }
 }

--- a/lib/OpenTracing/Tracer.pm
+++ b/lib/OpenTracing/Tracer.pm
@@ -64,7 +64,7 @@ sub process {
         OpenTracing::Process->new(
             pid              => $$,
             ip               => Net::Address::IP::Local->public_ipv4,
-            'tracer.version' => 'perl-OpenTracing-' . __PACKAGE__->VERSION,
+            'tracer.version' => 'perl-OpenTracing-' . (__PACKAGE__->VERSION // "0.0.0"),
         );
     }
 }


### PR DESCRIPTION
This PR adds a way to add References as per [jaeger.thrift protocol specs](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift#L58).
- Added new Reference class
- Added the Jaeger Protocol support for references
- Fixed obsolete code that wasn't passing the required process tags
