### PR TITLE
Added proper api to create context propagation

### DIFF
--- a/lib/OpenTracing/Integration/System.pm
+++ b/lib/OpenTracing/Integration/System.pm
@@ -37,11 +37,11 @@ Luckily, this perl module can do that for you using:
   my $span;
   if ($span_context)
   {
-      $span = $tracer->span_from_context(operation_name => 'main_with_context_propagation', context => $span_context);
+    $span = $tracer->span(operation_name => 'main', references => [$tracer->child_of($span_context)]);
   }
   else
   {
-      $span = $tracer->span(operation_name => 'main');
+    $span = $tracer->span(operation_name => 'main');
   }
 
 =head1 DESCRIPTION
@@ -65,7 +65,7 @@ sub load {
         *CORE::GLOBAL::system = sub {
             my @args = @_;
 
-            my $span = $tracer->span(operation_name => "CORE::system");
+            my $span = $tracer->span(operation_name => "system");
             $span->tag('command' => join(" ", @args));
             $class->inject_context($span);
 

--- a/lib/OpenTracing/Process.pm
+++ b/lib/OpenTracing/Process.pm
@@ -42,14 +42,6 @@ The process name. Freeform text string.
 
 sub name { shift->{name} //= "$0" }
 
-=head2 pid
-
-The process pid.
-
-=cut
-
-sub pid { shift->{pid} //= $$ }
-
 =head2 tags
 
 Arrayref of tags relating to the process.

--- a/lib/OpenTracing/Protocol/Jaeger.pm
+++ b/lib/OpenTracing/Protocol/Jaeger.pm
@@ -190,15 +190,15 @@ sub encode_span {
                     # trace_id_low
                     10,
                     2,
-                    substr($reference->span->trace_id, 16, 16),
+                    substr($reference->context->trace_id, 16, 16),
                     # trace_id_high
                     10,
                     3,
-                    substr($reference->span->trace_id, 0, 16),
+                    substr($reference->context->trace_id, 0, 16),
                     # span_id
                     10,
                     4,
-                    substr($reference->span->id, 0, 16),
+                    substr($reference->context->id, 0, 16),
                     0;
         }
     }

--- a/lib/OpenTracing/Reference.pm
+++ b/lib/OpenTracing/Reference.pm
@@ -36,11 +36,11 @@ sub ref_type { shift->{ref_type} }
 
 =head2 span
 
-The span for this reference.
+The context for this reference.
 
 =cut
 
-sub span { shift->{span} }
+sub context { shift->{context} }
 
 1;
 

--- a/lib/OpenTracing/Span.pm
+++ b/lib/OpenTracing/Span.pm
@@ -53,8 +53,8 @@ sub new {
     my ($class, %args) = @_;
     $args{operation_name} //= (caller 1)[3];
     if(my $parent = $args{parent}) {
-        $args{parent_id} = $parent->id;
-        $args{trace_id} = $parent->trace_id;
+        $args{parent_id} = $parent->{id};
+        $args{trace_id} = $parent->{trace_id};
     }
 
     # Alternatively reduce { $a * 1_000_000 + $b } Time::HiRes::gettimeofday(),

--- a/lib/OpenTracing/SpanProxy.pm
+++ b/lib/OpenTracing/SpanProxy.pm
@@ -61,6 +61,8 @@ sub references { shift->span->references }
 
 sub start_time { shift->span->start_time }
 
+sub finish_time { shift->span->finish_time }
+
 sub duration { shift->span->duration(@_) }
 
 sub finish { shift->span->finish(@_) }


### PR DESCRIPTION
Added the proper api to do context propagation according to [opentracing specs](https://opentracing.io/docs/overview/inject-extract/#the-basic-approach-inject-extract-and-carriers).  Fixed a problem where Process pid was set twice.

Requires:
https://github.com/team-at-cpan/Net-Async-OpenTracing/pull/3